### PR TITLE
Handle empty directory in upload

### DIFF
--- a/acdtools
+++ b/acdtools
@@ -241,22 +241,26 @@ function ACDToolsUpload {
     fi
 
     # Upload to Amazon Drive
-    until ${ACDCLI} upload -o ${ACDEXCLUDE} ${MOUNTBASE}/local-encrypted/* \
-        ${ACDSUBDIR}
-    do
-        ULATTEMPTS=$((ULATTEMPTS+1))
-        ACDToolsLog error "Some uploads failed - uploading again after a sync \
-            (attempt ${ULATTEMPTS})"
+	if [ "$(ls -A ${MOUNTBASE}/local-encrypted/*)" ]; then
+	    until ${ACDCLI} upload -o ${ACDEXCLUDE} ${MOUNTBASE}/local-encrypted/* \
+	        ${ACDSUBDIR}
+	    do
+	        ULATTEMPTS=$((ULATTEMPTS+1))
+	        ACDToolsLog error "Some uploads failed - uploading again after a sync \
+	            (attempt ${ULATTEMPTS})"
 
-        if [ "${ULATTEMPTS}" -ge 3 ]; then
-            ACDToolsLog error "Uploads failed 3 (or more) times - Forcing full \
-                sync"
-            ACDToolsSyncNodes full
-        else
-            ACDToolsSyncNodes
-        fi
-        sleep 60
-    done
+	        if [ "${ULATTEMPTS}" -ge 3 ]; then
+	            ACDToolsLog error "Uploads failed 3 (or more) times - Forcing full \
+	                sync"
+	            ACDToolsSyncNodes full
+	        else
+	            ACDToolsSyncNodes
+	        fi
+	        sleep 60
+	    done
+	else
+		echo "${MOUNTBASE}/local-encrypted/* is empty - nothing to upload"
+	fi
 
     ACDToolsLog info "Upload Complete - Syncing changes"
     ACDToolsSyncNodes

--- a/acdtools
+++ b/acdtools
@@ -241,7 +241,9 @@ function ACDToolsUpload {
     fi
 
     # Upload to Amazon Drive
-	if [ "$(ls -A ${MOUNTBASE}/local-encrypted/*)" ]; then
+	# Redirect error to `/dev/null` so as not to pollute the output with an
+	# `Input/output error`.
+	if [ "$(ls -A ${MOUNTBASE}/local-encrypted/* 2> /dev/null)" ] ; then
 	    until ${ACDCLI} upload -o ${ACDEXCLUDE} ${MOUNTBASE}/local-encrypted/* \
 	        ${ACDSUBDIR}
 	    do

--- a/acdtools
+++ b/acdtools
@@ -259,7 +259,7 @@ function ACDToolsUpload {
 	        sleep 60
 	    done
 	else
-		echo "${MOUNTBASE}/local-encrypted/* is empty - nothing to upload"
+		ACDToolsLog info "${MOUNTBASE}/local-encrypted/* is empty - nothing to upload"
 	fi
 
     ACDToolsLog info "Upload Complete - Syncing changes"


### PR DESCRIPTION
Fixes #37 

Without this change and an empty directory:

```
root@ns312644:~# /root/ACDTools/acdtools upload
[2017-03-18 23:36:46] [INFO ] Using configuration at /root/ACDTools/vars
[2017-03-18 23:36:46] [INFO ] No .unionfs-fuse/ directory found, nothing to delete
[2017-03-18 23:36:47] [INFO ] Will not upload H4GJKRUHV5WXDDE55XPMPK346EEVN directory (.unionfs-fuse)
17-03-18 23:36:47.577 [ERROR] [acd_cli] - Path "/root/.mounts/local-encrypted/*" does not exist.
[2017-03-18 23:36:47] [ERROR] Some uploads failed - uploading again after a sync (attempt 1)
[2017-03-18 23:36:47] [INFO ] Syncing acdcli node cache database
[2017-03-18 23:36:48] [INFO ] Syncing...
[2017-03-18 23:36:48] [INFO ] Done.
```

Then with this change:

```
root@ns312644:~# /root/ACDTools/acdtools upload
[2017-03-18 23:37:59] [INFO ] Using configuration at /root/ACDTools/vars
[2017-03-18 23:37:59] [INFO ] No .unionfs-fuse/ directory found, nothing to delete
[2017-03-18 23:38:00] [INFO ] Will not upload H4GJKRUHV5WXDDE55XPMPK346EEVN directory (.unionfs-fuse)
ls: cannot access '/root/.mounts/local-encrypted/*': Input/output error
/root/.mounts/local-encrypted/* is empty - nothing to upload
[2017-03-18 23:38:00] [INFO ] Upload Complete - Syncing changes
[2017-03-18 23:38:00] [INFO ] Syncing acdcli node cache database
[2017-03-18 23:38:00] [INFO ] Syncing...
[2017-03-18 23:38:01] [INFO ] Done.
```

```
root@ns312644:~# touch /root/data/test
root@ns312644:~#
```

```
root@ns312644:~# /root/ACDTools/acdtools upload
[2017-03-18 23:38:29] [INFO ] Using configuration at /root/ACDTools/vars
[2017-03-18 23:38:29] [INFO ] No .unionfs-fuse/ directory found, nothing to delete
[2017-03-18 23:38:30] [INFO ] Will not upload H4GJKRUHV5WXDDE55XPMPK346EEVN directory (.unionfs-fuse)
[#########################] 100.0% of      0B  1/1     0.0B/s       0s
[2017-03-18 23:38:31] [INFO ] Upload Complete - Syncing changes
[2017-03-18 23:38:31] [INFO ] Syncing acdcli node cache database
[2017-03-18 23:38:32] [INFO ] Syncing...
[2017-03-18 23:38:32] [INFO ] Done.
[2017-03-18 23:38:33] [INFO ] Last sync was very recent or has invalid date. Waiting 1m 40s.
```